### PR TITLE
Remove print statements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ exclude_lines =
     def __repr__
     raise NotImplementedError
     if __name__ == .__main__.:
+    any\(
 fail_under = 80
 omit =
     venv/**

--- a/ultimatepython/advanced/async.py
+++ b/ultimatepython/advanced/async.py
@@ -30,17 +30,13 @@ def _current_time():
 async def start_job(delay, job_id):
     """Start job_id after a certain delay in seconds."""
     queue_time = _current_time()
-    print(f"{queue_time} -> Queue job {job_id[:16]}...")
     await asyncio.sleep(delay)
     start_time = _current_time()
-    print(f"{start_time} -> Start job {job_id[:16]}...")
     return JobRecord(job_id, queue_time, start_time)
 
 
 async def schedule_jobs():
     """Schedule jobs concurrently."""
-    print(f"{_current_time()} -> Send kickoff email")
-
     # Create a job which also represents a coroutine
     single_job = start_job(_MILLISECOND, uuid4().hex)
     assert asyncio.iscoroutine(single_job)
@@ -69,8 +65,6 @@ async def schedule_jobs():
 
     for batch_record in batch_records:
         assert _is_valid_record(batch_record)
-
-    print(f"{_current_time()} -> Send confirmation email")
 
 
 def main():

--- a/ultimatepython/advanced/benchmark.py
+++ b/ultimatepython/advanced/benchmark.py
@@ -3,6 +3,8 @@ import pstats
 import time
 
 # Module-level constants
+from io import StringIO
+
 _SLEEP_DURATION = .001
 
 
@@ -34,7 +36,8 @@ def main():
     # There are other ways to sort the stats by, but this is the most
     # common way of doing so. For more info, please consult Python docs:
     # https://docs.python.org/3/library/profile.html
-    ps = pstats.Stats(profile).sort_stats("cumulative")
+    bytes_obj = StringIO()
+    ps = pstats.Stats(profile, stream=bytes_obj).sort_stats("cumulative")
 
     # Notice how many times each function was called. In this case, the main
     # bottleneck for `finish_slower` and `finish_faster` is `time.sleep`
@@ -45,6 +48,11 @@ def main():
     # large projects. Consider profiling in isolation when analyzing complex
     # classes and functions
     ps.print_stats()
+
+    lines = bytes_obj.getvalue().split("\n")
+    time_sleep_called = any("60" in line and "time.sleep" in line
+                            for line in lines)
+    assert time_sleep_called is True
 
 
 if __name__ == "__main__":

--- a/ultimatepython/advanced/decorator.py
+++ b/ultimatepython/advanced/decorator.py
@@ -1,33 +1,4 @@
-from contextlib import contextmanager
 from functools import wraps
-
-# Module-level constants
-_HEADER = "---"
-
-
-@contextmanager
-def header_section():
-    """Print header line first before running anything.
-
-    Notice a context manager is used so that we enter a block where a header
-    is printed out before proceeding with the function call at the point
-    of yielding.
-
-    Also notice that `header_section` is a coroutine that is wrapped by
-    `contextmanager`. The `contextmanager` handles entering and exiting a
-    section of code without defining a full-blown class to handle `__enter__`
-    and `__exit__` use cases.
-
-    There are many more use cases for context managers, like
-    writing / reading data from a file. Another one is protecting database
-    integrity while sending CREATE / UPDATE / DELETE statements over the
-    network. For more on how context managers work, please consult the
-    Python docs for more information.
-
-    https://docs.python.org/3/library/contextlib.html
-    """
-    print(_HEADER)
-    yield
 
 
 def run_with_stringy(fn):
@@ -108,16 +79,15 @@ def main():
 
     # See what changed between the insecure data and the secure data
     for insecure_item, secure_item in zip(insecure_data, secure_data):
-        with header_section():
-            print("Insecure item", insecure_item)
-            print("Secure item", secure_item)
+        assert insecure_item != secure_item
 
     # Throw an error on a collection with non-string objects
+    input_fails = False
     try:
         hide_content([1])
-    except ValueError as e:
-        with header_section():
-            print(e)
+    except ValueError:
+        input_fails = True
+    assert input_fails is True
 
 
 if __name__ == "__main__":

--- a/ultimatepython/advanced/meta_class.py
+++ b/ultimatepython/advanced/meta_class.py
@@ -133,15 +133,12 @@ class AddressModel(BaseModel):
 
 def main():
     # Each model was modified at runtime with ModelMeta
-    for real_model in BaseModel.__subclasses__():
-        assert real_model.is_registered
-        print("Real model name", real_model.model_name)
-        print("Real model fields", real_model.model_fields)
-        print("Real model table", real_model.model_table)
+    assert UserModel.model_name == "user_rocks"
+    assert AddressModel.model_name == "address"
 
     # Each model was registered at runtime with ModelMeta
-    for meta_table in ModelMeta.tables.values():
-        print("ModelMeta table", meta_table)
+    assert UserModel.model_name in ModelMeta.tables
+    assert AddressModel.model_name in ModelMeta.tables
 
     # Base model was given special treatment, as expected
     assert not BaseModel.is_registered

--- a/ultimatepython/advanced/mro.py
+++ b/ultimatepython/advanced/mro.py
@@ -2,17 +2,17 @@ class BasePlayer:
     """Base player."""
 
     def ping(self):
-        print("ping", self)
+        return f"ping {type(self).__name__}"
 
     def pong(self):
-        print("pong", self)
+        return f"pong {type(self).__name__}"
 
 
 class PongPlayer(BasePlayer):
     """Pong player."""
 
     def pong(self):
-        print("PONG", self)
+        return f"PONG {type(self).__name__}"
 
 
 class NeutralPlayer(BasePlayer):
@@ -37,14 +37,16 @@ class ConfusedPlayer(PongPlayer, NeutralPlayer):
 
     def ping(self):
         """Override `ping` method."""
-        print("pINg", self)
+        return f"pINg {type(self).__name__}"
 
     def ping_pong(self):
         """Run `ping` and `pong` in different ways."""
-        self.ping()
-        super().ping()
-        self.pong()
-        super().pong()
+        return [
+            self.ping(),
+            super().ping(),
+            self.pong(),
+            super().pong()
+        ]
 
 
 class IndecisivePlayer(NeutralPlayer, PongPlayer):
@@ -61,14 +63,16 @@ class IndecisivePlayer(NeutralPlayer, PongPlayer):
 
     def pong(self):
         """Override `pong` method."""
-        print("pONg", self)
+        return f"pONg {type(self).__name__}"
 
     def ping_pong(self):
         """Run `ping` and `pong` in different ways."""
-        self.ping()
-        super().ping()
-        self.pong()
-        super(PongPlayer, self).pong()  # bypass MRO to `BasePlayer`
+        return [
+            self.ping(),
+            super().ping(),
+            self.pong(),
+            super(PongPlayer, self).pong()  # bypass MRO to `BasePlayer`
+        ]
 
 
 def main():
@@ -86,14 +90,16 @@ def main():
     # Show `IndecisivePlayer` method resolution in action
     IndecisivePlayer().ping_pong()
 
+    class_creation_fails = False
     try:
         # Creating a new class `ConfusedPlayer` and `IndecisivePlayer`
         # result in a `TypeError` because both classes have mismatched
         # MRO outputs. This means that they cannot be reconciled as
         # one class. Hence `MissingPlayer` will not be created
         type("MissingPlayer", (ConfusedPlayer, IndecisivePlayer), {})
-    except TypeError as e:
-        print(e)
+    except TypeError:
+        class_creation_fails = True
+    assert class_creation_fails is True
 
 
 if __name__ == '__main__':

--- a/ultimatepython/advanced/weak_ref.py
+++ b/ultimatepython/advanced/weak_ref.py
@@ -63,9 +63,6 @@ def setup_and_teardown_servers(registry):
                 for server in servers])
     )
 
-    # Print server count as proof
-    print("Server count", registry.server_count)
-
     # What's really interesting is that servers go away when we leave the
     # scope of this function. In this function, each server is created and
     # strongly referenced by the `app_servers` variable. When we leave this
@@ -89,9 +86,6 @@ def main():
     # desired if we want to keep our software memory-efficient
     assert registry.servers == set()
     assert registry.server_count == 0
-
-    # Print server count as proof
-    print("Server count", registry.server_count)
 
 
 if __name__ == '__main__':

--- a/ultimatepython/classes/abstract_class.py
+++ b/ultimatepython/classes/abstract_class.py
@@ -18,21 +18,14 @@ class Employee(ABC):
         self.title = title
 
     def __str__(self):
-        return f"{self.name} ({self.title})"
-
-    def __repr__(self):
-        return f"<{type(self).__name__} name={self.name}>"
+        return self.name
 
     @abstractmethod
     def do_work(self):
         raise NotImplementedError
 
     @abstractmethod
-    def join_meeting(self):
-        raise NotImplementedError
-
-    @abstractmethod
-    def relax(self):
+    def do_relax(self):
         raise NotImplementedError
 
 
@@ -52,17 +45,14 @@ class Engineer(Employee):
         self.skill = skill
 
     def do_work(self):
-        print(f"{self} is coding in {self.skill}")
+        return f"{self} is coding in {self.skill}"
 
-    def join_meeting(self):
-        print(f"{self} is joining a meeting on {self.skill}")
-
-    def relax(self):
-        print(f"{self} is relaxing by watching YouTube")
+    def do_relax(self):
+        return f"{self} is watching YouTube"
 
     def do_refactor(self):
         """Do the hard work of refactoring code, unlike managers."""
-        print(f"{self} is refactoring code")
+        return f"{self} is refactoring code"
 
 
 class Manager(Employee):
@@ -79,17 +69,14 @@ class Manager(Employee):
         self.direct_reports = direct_reports
 
     def do_work(self):
-        print(f"{self} is meeting up with {self.direct_reports}")
+        return f"{self} is meeting up with {len(self.direct_reports)} reports"
 
-    def join_meeting(self):
-        print(f"{self} is joining a meeting with {self.direct_reports}")
-
-    def relax(self):
-        print(f"{self} is taking a trip to the Bahamas")
+    def do_relax(self):
+        return f"{self} is taking a trip to the Bahamas"
 
     def do_hire(self):
         """Do the hard work of hiring employees, unlike engineers."""
-        print(f"{self} is hiring employees")
+        return f"{self} is hiring employees"
 
 
 def main():
@@ -97,28 +84,22 @@ def main():
     engineer_john = Engineer("John Doe", "Software Engineer", "Android")
     engineer_jane = Engineer("Jane Doe", "Software Engineer", "iOS")
 
-    engineers = [engineer_john, engineer_jane]
-    for engineer in engineers:
-        assert isinstance(engineer, (Engineer, Employee))
-        assert not isinstance(engineer, Manager)
-        print("Created", repr(engineer))
-
-        engineer.do_work()
-        engineer.join_meeting()
-        engineer.relax()
-        engineer.do_refactor()
+    assert isinstance(engineer_john, (Engineer, Employee))
+    assert not isinstance(engineer_john, Manager)
+    assert engineer_john.do_work() == "John Doe is coding in Android"
+    assert engineer_john.do_relax() == "John Doe is watching YouTube"
+    assert engineer_john.do_refactor() == "John Doe is refactoring code"
 
     # Declare manager with engineers as direct reports
+    engineers = [engineer_john, engineer_jane]
     manager_max = Manager("Max Doe", "Engineering Manager", engineers)
 
     assert isinstance(manager_max, (Manager, Employee))
     assert not isinstance(manager_max, Engineer)
-    print("Created", repr(manager_max))
 
-    manager_max.do_work()
-    manager_max.join_meeting()
-    manager_max.relax()
-    manager_max.do_hire()
+    assert manager_max.do_work() == "Max Doe is meeting up with 2 reports"
+    assert manager_max.do_relax() == "Max Doe is taking a trip to the Bahamas"
+    assert manager_max.do_hire() == "Max Doe is hiring employees"
 
 
 if __name__ == '__main__':

--- a/ultimatepython/classes/basic_class.py
+++ b/ultimatepython/classes/basic_class.py
@@ -27,7 +27,7 @@ class Car:
 
     def drive(self, rate_in_mph):
         """Drive car at a certain rate."""
-        print(f"{self} is driving at {rate_in_mph} MPH")
+        return f"{self} is driving at {rate_in_mph} MPH"
 
 
 def main():
@@ -38,7 +38,7 @@ def main():
     assert repr(car) != str(car)
 
     # Call a method on the class constructor
-    car.drive(75)
+    assert car.drive(75) == "Bumble Bee (2000) is driving at 75 MPH"
 
     # As a reminder: everything in Python is an object! And that applies
     # to classes in the most interesting way - because they're not only

--- a/ultimatepython/classes/exception_class.py
+++ b/ultimatepython/classes/exception_class.py
@@ -59,9 +59,11 @@ def main():
         try:
             divide_positive_numbers(dividend, divisor)
         except DivisionError as e:
-            print(e)
+            assert str(e).startswith("Cannot have a")
+
+    # Now let's do it correctly to skip all the exceptions
     result = divide_positive_numbers(1, 1)
-    print(f"Divide(1, 1) = {result}")
+    assert result == 1
 
 
 if __name__ == '__main__':

--- a/ultimatepython/classes/iterator_class.py
+++ b/ultimatepython/classes/iterator_class.py
@@ -1,3 +1,7 @@
+# Module-level constants
+_ITERATION_MESSAGE = "Cyclic loop detected"
+
+
 class Employee:
     """Generic employee class.
 
@@ -79,7 +83,7 @@ class EmployeeIterator:
             raise StopIteration
         employee = self.employees_to_visit.pop()
         if employee.name in self.employees_visited:
-            raise IterationError("Cyclic loop detected")
+            raise IterationError(_ITERATION_MESSAGE)
         self.employees_visited.add(employee.name)
         for report in employee.direct_reports:
             self.employees_to_visit.append(report)
@@ -111,7 +115,7 @@ def employee_generator(top_employee):
     while len(to_visit) > 0:
         employee = to_visit.pop()
         if employee.name in visited:
-            raise IterationError("Cyclic loop detected")
+            raise IterationError(_ITERATION_MESSAGE)
         visited.add(employee.name)
         for report in employee.direct_reports:
             to_visit.append(report)
@@ -133,7 +137,6 @@ def main():
 
     # Make sure that the employees are who we expect them to be
     assert all(isinstance(emp, Employee) for emp in employees)
-    print(employees)
 
     # This is not a good day for this company
     hacker = Employee("Unknown", "Hacker", [])
@@ -143,7 +146,7 @@ def main():
         try:
             list(iter_fn(hacker))
         except IterationError as e:
-            print(e)
+            assert str(e) == _ITERATION_MESSAGE
 
 
 if __name__ == "__main__":

--- a/ultimatepython/data_structures/comprehension.py
+++ b/ultimatepython/data_structures/comprehension.py
@@ -6,24 +6,26 @@ def main():
     # we can set the item that we compute with to `_`; and we want to
     # create five zeros so we set the iterator as `range(5)`
     list_comp = [0 for _ in range(5)]
-    print("List of zeros", list_comp)
+    assert list_comp == [0] * 5
 
     words = ["cat", "mice", "horse", "bat"]
 
     # Tuple comprehension can find the length for each word
     tuple_comp = tuple(len(word) for word in words)
-    assert len(tuple_comp) == len(words)
-    print("Tuple of word lengths", tuple_comp)
+    assert tuple_comp == (3, 4, 5, 3)
 
     # Set comprehension can find the unique word lengths
     set_comp = {len(word) for word in words}
     assert len(set_comp) < len(words)
-    print("Set of word lengths", set_comp)
+    assert set_comp == {3, 4, 5}
 
     # Dictionary comprehension can map each word to its length
     dict_comp = {word: len(word) for word in words}
     assert len(dict_comp) == len(words)
-    print("Mapping of word to length", dict_comp)
+    assert dict_comp == {"cat": 3,
+                         "mice": 4,
+                         "horse": 5,
+                         "bat": 3}
 
 
 if __name__ == "__main__":

--- a/ultimatepython/data_structures/dict.py
+++ b/ultimatepython/data_structures/dict.py
@@ -24,7 +24,7 @@ def main():
 
     # We can access the student and GPA simultaneously
     for student, gpa in student_gpa.items():
-        print(f"Student {student} has a {gpa} GPA")
+        assert student_gpa[student] == gpa
 
 
 if __name__ == "__main__":

--- a/ultimatepython/data_structures/list.py
+++ b/ultimatepython/data_structures/list.py
@@ -3,7 +3,8 @@ def main():
     # "a" is a string at index 0 and
     # "e" is a string at index 4
     letters = ["a", "b", "c", "d", "e"]
-    print("Letters", letters)
+    assert letters[0] == "a"
+    assert letters[4] == letters[-1] == "e"
 
     for letter in letters:
         # Each of the strings is one character
@@ -22,10 +23,11 @@ def main():
     assert letters[::-1] == ["e", "d", "c", "b", "a"]
 
     # This is a list of integers where
-    # 1 is an integer at index 0
+    # 1 is an integer at index 0 and
     # 5 is an integer at index 4
     numbers = [1, 2, 3, 4, 5]
-    print("Numbers", numbers)
+    assert numbers[0] == 1
+    assert numbers[4] == numbers[-1] == 5
 
     # Note that a list is ordered and mutable. If we want to reverse the order
     # of the `numbers` list, we can start at index 0 and end halfway. At each
@@ -40,22 +42,20 @@ def main():
 
     # Print letters and numbers side-by-side using the `zip` function. Notice
     # that we pair the letter at index 0 with the number at index 0, and
-    # do the same for the remaining indices
-    for letter, number in zip(letters, numbers):
-        print("Letter and number", letter, number)
+    # do the same for the remaining indices. To see the indices and values
+    # of a list at the same time, we can use `enumerate` to transform the
+    # list of values into an iterator of index-number pairs
+    for index, (letter, number) in enumerate(zip(letters, numbers)):
+        assert letters[index] == letter
+        assert numbers[index] == number
 
     # The `for` loop worked because the lengths of both lists are equal
     assert len(letters) == len(numbers)
 
-    # To see the indices and values of a list at the same time, we can use
-    # `enumerate` to transform the list of values into an iterator of
-    # index-number pairs
-    for index, number in enumerate(numbers):
-        print(f"At numbers[{index}]", number)
-
     # Lists can be nested at arbitrary levels
     matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-    print("Matrix of lists", matrix)
+    assert matrix[1][0] == 4
+    assert matrix[0][1] == 2
 
     # This matrix just so happens to be a square so the the length of each
     # row is the same as the number of rows in the matrix
@@ -65,10 +65,11 @@ def main():
     # Notice that lists have variable length and can be modified to have
     # more elements. Lists can also be modified to have fewer elements
     lengthy = []
-    for i in range(5):  # [0, 1, 2, 3, 4]
-        lengthy.append(i)
-    lengthy.pop()  # pop out the 4
-    print("Lengthy list", lengthy)
+    for i in range(5):
+        lengthy.append(i)  # add 0..4 to the back
+    assert lengthy == [0, 1, 2, 3, 4]
+    lengthy.pop()  # pop out the 4 from the back
+    assert lengthy == [0, 1, 2, 3]
 
 
 if __name__ == "__main__":

--- a/ultimatepython/data_structures/set.py
+++ b/ultimatepython/data_structures/set.py
@@ -1,5 +1,19 @@
 def main():
-    # Define two `set` collections
+    # Let's define one `set` for starters
+    simple_set = {0, 1, 2}
+
+    # A set is dynamic like a `list` and `tuple`
+    simple_set.add(3)
+    simple_set.add(4)
+
+    # Unlike a `list and `tuple`, it is not an ordered sequence as it
+    # prevent duplicates from being added
+    for _ in range(5):
+        simple_set.add(0)
+        simple_set.add(4)
+    assert simple_set == {0, 1, 2, 3, 4}
+
+    # Now let's define two `set` collections
     multiples_two = set()
     multiples_four = set()
 
@@ -8,8 +22,9 @@ def main():
         multiples_two.add(i * 2)
         multiples_four.add(i * 4)
 
-    print("Multiples of two", multiples_two)
-    print("Multiples of three", multiples_four)
+    # As we can see, both sets have similarities and differences
+    assert multiples_two == {0, 2, 4, 6, 8, 10, 12, 14, 16, 18}
+    assert multiples_four == {0, 4, 8, 12, 16, 20, 24, 28, 32, 36}
 
     # We cannot decide in which order the numbers come out - so let's
     # look for fundamental truths instead, such as divisibility against
@@ -18,8 +33,6 @@ def main():
     multiples_common = multiples_two.intersection(multiples_four)
     for number in multiples_common:
         assert number % 2 == 0 and number % 4 == 0
-
-    print("Multiples in common", multiples_common)
 
     # We can compute exclusive multiples
     multiples_two_exclusive = multiples_two.difference(multiples_four)
@@ -31,13 +44,9 @@ def main():
     for number in multiples_four_exclusive:
         assert 18 < number < 40
 
-    print("Exclusive multiples of two", multiples_two_exclusive)
-    print("Exclusive multiples of four", multiples_four_exclusive)
-
     # By computing a set union against the two sets, we have all integers
     # in this program
     multiples_all = multiples_two.union(multiples_four)
-    print("All multiples", multiples_all)
 
     # Check if set A is a subset of set B
     assert multiples_four_exclusive.issubset(multiples_four)

--- a/ultimatepython/data_structures/string.py
+++ b/ultimatepython/data_structures/string.py
@@ -1,11 +1,5 @@
 # Module-level constants
 _DELIMITER = " | "
-_PADDING = 10
-
-
-def label(name, padding=_PADDING):
-    """Get name as title with right-side padding."""
-    return f"{name.title()}:".ljust(padding)
 
 
 def main():
@@ -20,13 +14,10 @@ def main():
     assert content[9:15] == "Python"
     assert content[::-1] == "ediug yduts nohtyP etamitlU"
 
-    # And unsurprisingly, we can print its contents as well
-    print(label("original"), content)
-
     # Like tuples, we cannot change the data in a string. However, we can
     # create a new string from existing strings
     new_content = f"{content.upper()}{_DELIMITER}{content.lower()}"
-    print(label("new"), new_content)
+    assert _DELIMITER in new_content
 
     # We can split one string into a list of strings
     split_content = new_content.split(_DELIMITER)
@@ -45,10 +36,6 @@ def main():
     assert lower_content in new_content
     assert new_content.endswith(lower_content)
 
-    # Let's print the split variables for visual proof
-    print(label("upper"), upper_content)
-    print(label("lower"), lower_content)
-
     # Notice that `upper_content` and `lower_content` are smaller
     # than `new_content` and have the same length as the original
     # `content` they were derived from
@@ -62,7 +49,6 @@ def main():
     joined_content = _DELIMITER.join(split_content)
     assert isinstance(joined_content, str)
     assert new_content == joined_content
-    print(label("joined"), joined_content)
 
 
 if __name__ == '__main__':

--- a/ultimatepython/data_structures/tuple.py
+++ b/ultimatepython/data_structures/tuple.py
@@ -1,21 +1,21 @@
 def main():
     # This is a tuple of integers
     immutable = (1, 2, 3, 4)
-    print(immutable)
 
     # It can be indexed like a list
     assert immutable[0] == 1
+    assert immutable[-1] == 4
 
     # It can be iterated over like a list
-    for number in immutable:
-        print("Immutable", number)
+    for ix, number in enumerate(immutable):
+        assert immutable[ix] == number
 
     # But its contents cannot be changed. As an alternative, we can
     # create new tuples from existing tuples
     bigger_immutable = immutable + (5, 6)
-    print(bigger_immutable)
+    assert bigger_immutable == (1, 2, 3, 4, 5, 6)
     smaller_immutable = immutable[0:2]
-    print(smaller_immutable)
+    assert smaller_immutable == (1, 2)
 
 
 if __name__ == "__main__":

--- a/ultimatepython/syntax/conditional.py
+++ b/ultimatepython/syntax/conditional.py
@@ -3,33 +3,41 @@ def main():
     x_add_two = x + 2
 
     # This condition is obviously true
+    ran_1 = False
     if x_add_two == 3:  # skip: else
-        print("Math wins")  # run
+        ran_1 = True  # run
+    assert ran_1 is True
 
     # A negated condition can also be true
+    ran_2 = False
     if not x_add_two == 1:  # skip: else
-        print("Math wins here too")  # run
+        ran_2 = True  # run
+    assert ran_2 is True
 
     # There are `else` statements as well, which run if the initial condition
     # fails. Notice that one line gets skipped, and that this conditional
     # does not help one make a conclusion on the variable's true value
+    ran_3 = False
     if x_add_two == 1:
-        print("Math lost here...")  # skip: if
+        ran_3 = False  # skip: if
     else:
-        print("Math wins otherwise")  # run
+        ran_3 = True  # run
+    assert ran_3 is True
 
     # The `else` statement also run once all other `if` and `elif` conditions
     # fail. Notice that multiple lines get skipped, and that all of the
     # conditions could have been compressed to `x_add_two != 3` for
     # simplicity. In this case, less logic results in more clarity
+    ran_4 = False
     if x_add_two == 1:
-        print("Nope not this one...")  # skip: if
+        ran_4 = False  # skip: if
     elif x_add_two == 2:
-        print("Nope not this one either...")  # skip: if
+        ran_4 = False  # skip: if
     elif x_add_two < 3 or x_add_two > 3:
-        print("Nope not quite...")  # skip: if
+        ran_4 = False  # skip: if
     else:
-        print("Math wins finally")  # run
+        ran_4 = True  # run
+    assert ran_4 is True
 
 
 if __name__ == "__main__":

--- a/ultimatepython/syntax/expression.py
+++ b/ultimatepython/syntax/expression.py
@@ -3,25 +3,25 @@ def main():
     x = 1
 
     # Its value can used as part of expressions
-    print("Add integer", x + 1)
+    assert x + 1 == 2
 
     # An expression can be chained indefinitely. This concept of chaining
     # expressions is powerful because it allows us to compose simple pieces
     # of code into larger pieces of code over time
-    print("Multiply integers", x * 2 * 2 * 2)
+    assert x * 2 * 2 * 2 == 8
 
     # Division is a bit tricky in Python because it returns a result
     # of type 'float' by default
-    print("Divide as float", x / 2)
+    assert x / 2 == 0.5
 
     # If an integer division is desired, then an extra slash must be
     # added to the expression
-    print("Divide by integer", x // 2)
+    assert x // 2 == 0
 
     # Powers of an integer can be leveraged too. If more features are
     # needed, then leverage the builtin `math` library or a third-party
     # library. Otherwise, we have to build our own math library
-    print("Power of integer", x * 2 ** 3)
+    assert x * 2 ** 3 == 8
 
 
 if __name__ == "__main__":

--- a/ultimatepython/syntax/function.py
+++ b/ultimatepython/syntax/function.py
@@ -9,39 +9,42 @@ def add(x, y):
     return x + y
 
 
-def run_until(fn, n):
-    """Run a function from 0 until n - 1.
+def sum_until(fn, n):
+    """Sum a function output from 0 until n - 1.
 
     This expects a function to be provided as its first input and an integer
-    as its second input. Unlike `add`, `run_until` does NOT return a value.
+    as its second input. Like `add`, `run_until` returns a value.
 
     The fact that a function can be passed into `run_until` highlights a core
     concept that was mentioned before: everything in Python is an object, and
     that includes this docstring!
     """
+    total = 0
     for i in range(n):
-        fn(i)
+        total += fn(i)
+    return total
 
 
 def main():
     # The `add` function can be used for numbers as expected
     add_result_int = add(1, 2)
-    print(f"Add(1, 2) = {add_result_int}")
+    assert add_result_int == 3
 
     # The `add` function can be used for strings as well
     add_result_string = add("hello", " world")
-    print(f"Add('hello', ' world') = '{add_result_string}'")
+    assert add_result_string == "hello world"
 
-    # Run the input function twice. Notice that we make use of `lambda` to
-    # create an anonymous function (i.e. a function without a name) that
-    # accepts one input and does something with it. Anonymous functions
-    # are powerful because they allow one to write functions inline, unlike
-    # `add` and `run_until`
-    run_until(lambda i: print(f"Say hello at time = {i}"), 2)
+    # Run the input function multiple times. Notice that we make use of
+    # `lambda` to create an anonymous function (i.e. a function without
+    # a name) that accepts one input and does something with it. Anonymous
+    # functions are powerful because they allow one to write functions
+    # inline, unlike `add` and `run_until`
+    run_results = sum_until(lambda i: i * 100, 5)
+    assert run_results == 1000, run_results
 
     # We can see the `run_until` docstring by accessing the `__doc__` magic
     # attribute! Remember this - everything in Python is an object
-    print(run_until.__doc__)
+    assert "includes this docstring!" in sum_until.__doc__
 
 
 if __name__ == "__main__":

--- a/ultimatepython/syntax/loop.py
+++ b/ultimatepython/syntax/loop.py
@@ -8,7 +8,7 @@ def main():
         total += i
 
     # The answer is...10!
-    print(f"Sum(0..4) = {total}")
+    assert total == 10
 
     # This is a `for` loop that iterates on values 5..1 and multiplies each
     # value to `fib`. The `range` iterator is used here more explicitly by
@@ -19,7 +19,7 @@ def main():
         fib *= i
 
     # The answer is...120!
-    print(f"Fibonacci(5..1) = {fib}")
+    assert fib == 120
 
     # This is a simple `while` loop, similar to a `for` loop except that the
     # counter is declared outside of the loop and its state is explicitly
@@ -27,8 +27,10 @@ def main():
     # exceeds 8
     i = 0
     while i < 8:
-        print(f"While {i} < 5")
         i += 2
+
+    # The `while` loop terminated at this value
+    assert i == 8
 
     # This is a `while` loop that is stopped with `break` and its counter is
     # multiplied in the loop, showing that we can do anything to the
@@ -36,27 +38,21 @@ def main():
     # the counter exceeds 8
     i = 1
     while True:
-        print(f"Do while {i} < 5")
         i *= 2
 
-        # Putting this conditional after the `print` statement makes the loop
-        # look like the do-while loop from other programming languages
         if i >= 8:
-            print(f"Break out! {i} is no longer < 5")
-
             # The `break` statement stops the current `while` loop.
             # If this `while` loop was nested in another loop,
             # this statement would not stop the parent loop
             break
 
         if i == 2:
-            print(f"Time to continue from {i}")
-
             # The `continue` statement returns to the start of the
             # current `while` loop
             continue
 
-        print(f"Staying alive at {i}")
+    # The `while` loop terminated at this value
+    assert i == 8
 
 
 if __name__ == "__main__":

--- a/ultimatepython/syntax/variable.py
+++ b/ultimatepython/syntax/variable.py
@@ -28,13 +28,6 @@ def main():
     assert isinstance(c, object) and isinstance(c_type, object)
     assert isinstance(d, object) and isinstance(d_type, object)
 
-    # Here is a summary via the `print` function. Notice that we print more
-    # than one variable at a time
-    print("a", a, a_type)
-    print("b", b, b_type)
-    print("c", c, c_type)
-    print("d", d, d_type)
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
After receiving some feedback, it seems like the `print` statement can be confused with the `assert` statements. Instead of mixing the two together, we use only `assert` statements going forward. This makes the code more test-driven as a result. Furthermore, the `assert` statements tell us at what line something failed, so we can always back-track if needed.