### PR TITLE
Replace fails with failed

### DIFF
--- a/ultimatepython/advanced/context_manager.py
+++ b/ultimatepython/advanced/context_manager.py
@@ -47,7 +47,7 @@ def main():
 
     # Examples of context manager failures
     for obj in (file, FileHandler):
-        call_fails = False
+        call_failed = False
         try:
             # Whenever any error happens in the context block, the buffer
             # in the context manager gets closed automatically and the
@@ -55,8 +55,8 @@ def main():
             with obj("c.out") as _:
                 raise RuntimeError("System crash. Abort!")
         except RuntimeError:
-            call_fails = True
-        assert call_fails is True
+            call_failed = True
+        assert call_failed is True
 
 
 if __name__ == "__main__":

--- a/ultimatepython/advanced/decorator.py
+++ b/ultimatepython/advanced/decorator.py
@@ -96,12 +96,12 @@ def main():
         assert _is_hidden(secure_item)
 
     # Throw an error on a collection with non-string objects
-    input_fails = False
+    input_failed = False
     try:
         hide_content([1])
     except ValueError:
-        input_fails = True
-    assert input_fails is True
+        input_failed = True
+    assert input_failed is True
 
 
 if __name__ == "__main__":

--- a/ultimatepython/advanced/mro.py
+++ b/ultimatepython/advanced/mro.py
@@ -90,7 +90,7 @@ def main():
     # Show `IndecisivePlayer` method resolution in action
     assert IndecisivePlayer().ping_pong() == ["ping", "ping", "pONg", "pong"]
 
-    class_creation_fails = False
+    class_creation_failed = False
     try:
         # Creating a new class `ConfusedPlayer` and `IndecisivePlayer`
         # results in a `TypeError` because both classes have mismatched
@@ -98,8 +98,8 @@ def main():
         # one class. Hence `MissingPlayer` will not be created
         type("MissingPlayer", (ConfusedPlayer, IndecisivePlayer), {})
     except TypeError:
-        class_creation_fails = True
-    assert class_creation_fails is True
+        class_creation_failed = True
+    assert class_creation_failed is True
 
 
 if __name__ == "__main__":

--- a/ultimatepython/classes/iterator_class.py
+++ b/ultimatepython/classes/iterator_class.py
@@ -143,12 +143,12 @@ def main():
     hacker.direct_reports.append(hacker)
 
     for obj in (EmployeeIterator, employee_generator):
-        call_fails = False
+        call_failed = False
         try:
             list(obj(hacker))
         except IterationError:
-            call_fails = True
-        assert call_fails is True
+            call_failed = True
+        assert call_failed is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Please read the [contributing guidelines](https://github.com/huangsam/ultimate-python/blob/master/CONTRIBUTING.md) before submitting a pull request.

---

**Describe the change**
Replace boolean flag suffixes from `fails` to `failed`.

**Additional context**
The `conditional` lesson already use flags with past-tense, so might as well keep it consistent for the other lessons.
