### PR TITLE
Reorder advanced section of ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,16 +92,16 @@ There are two ways of running the modules:
     - Iterator class: [Iterator definition | yield](ultimatepython/classes/iterator_class.py) (:exploding_head:)
 5. **Advanced**
     - Decorator: [Decorator definition | wraps](ultimatepython/advanced/decorator.py) (:exploding_head:)
-    - Metaclass: [Metaclass definition](ultimatepython/advanced/meta_class.py) (:exploding_head:)
+    - Context manager: [Context managers](ultimatepython/advanced/context_manager.py) (:exploding_head:)
     - Method resolution order: [mro](ultimatepython/advanced/mro.py) (:exploding_head:)
+    - Metaclass: [Metaclass definition](ultimatepython/advanced/meta_class.py) (:exploding_head:)
+    - Threads: [concurrent.futures](ultimatepython/advanced/threads.py) (:exploding_head:)
     - Asyncio: [async | await](ultimatepython/advanced/async.py) (:exploding_head:)
     - Weak reference: [weakref](ultimatepython/advanced/weak_ref.py) (:exploding_head:)
     - Benchmark: [cProfile | pstats](ultimatepython/advanced/benchmark.py) (:exploding_head:)
-    - Context manager: [Context managers](ultimatepython/advanced/context_manager.py) (:exploding_head:)
     - Mocking: [MagicMock | PropertyMock | patch](ultimatepython/advanced/mocking.py) (:exploding_head:)
     - Regular expression: [search | findall | match | fullmatch](ultimatepython/advanced/regex.py) (:exploding_head:)
     - Data format: [json | xml | csv](ultimatepython/advanced/data_format.py) (:exploding_head:)
-    - Threads: [concurrent.futures](ultimatepython/advanced/threads.py) (:exploding_head:)
 
 ## Additional resources
 


### PR DESCRIPTION
*Please read the [contributing guidelines](https://github.com/huangsam/ultimate-python/blob/master/CONTRIBUTING.md) before submitting a pull request.*

---

**Describe the change**
Reorder advanced section of ToC.

**Additional context**
The `README` ToC has increased in the amount of advanced topics. In order to keep things organized, I'm trying to cluster similar topics around each other in a way that enables a logical progression for advanced learners to improve their Python skills.