### PR TITLE
Implement deque lesson

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -74,6 +74,7 @@ Repl.it와 같은 브라우저에서 실행할 수있는 독립형 모듈 모음
     - Dict : [사전 작업](ultimatepython/data_structures/dict.py) (:cake:)
     - 이해력 : [목록 | 튜플 | 세트 | dict](ultimatepython/data_structures/comprehension.py)
     - 문자열 : [문자열 연산](ultimatepython/data_structures/string.py) (:cake:)
+    - Deque: [deque](ultimatepython/data_structures/deque.py) (:exploding_head:)
     - 시간 복잡성 : [cPython 작업](https://wiki.python.org/moin/TimeComplexity) (:books:, :exploding_head:)
 4. **클래스**
     - 기본 클래스 : [기본 정의](ultimatepython/classes/basic_class.py) (:cake:)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ There are two ways of running the modules:
     - Dict: [Dictionary operations](ultimatepython/data_structures/dict.py) (:cake:)
     - Comprehension: [list | tuple | set | dict](ultimatepython/data_structures/comprehension.py)
     - String: [String operations](ultimatepython/data_structures/string.py) (:cake:)
+    - Deque: [deque](ultimatepython/data_structures/deque.py) (:exploding_head:)
     - Time complexity: [cPython operations](https://wiki.python.org/moin/TimeComplexity) (:books:, :exploding_head:)
 4. **Classes**
     - Basic class: [Basic definition](ultimatepython/classes/basic_class.py) (:cake:)

--- a/ultimatepython/data_structures/deque.py
+++ b/ultimatepython/data_structures/deque.py
@@ -1,0 +1,41 @@
+from collections import deque
+
+
+def main():
+    # A list is identical to a vector where a new array is created when
+    # there are too many elements and the old elements are moved over to
+    # the new array one-by-one. The time complexity involved with growing
+    # its size is linear. A deque is identical to a doubly linked list
+    # whose nodes have a left pointer and a right pointer. In order to
+    # grow the linked list, a new node is created and added to the left
+    # or the right of the linked list. The time complexity involved with
+    # growing its size is constant. Check out the source code for a list
+    # and a deque to learn more:
+    # https://github.com/python/cpython/blob/3.8/Objects/listobject.c
+    # https://github.com/python/cpython/blob/3.8/Modules/_collectionsmodule.c
+    dq = deque()
+
+    for i in range(1, 5):
+        # Similar to adding a new node to the right of the linked list
+        dq.append(i)
+
+        # Similar to adding a new node to the left of the linked list
+        dq.appendleft(i * 2)
+
+    # A deque can be iterated on to build a sequence of choice
+    assert [el for el in dq] == [8, 6, 4, 2, 1, 2, 3, 4]
+    assert tuple(el for el in dq) == (8, 6, 4, 2, 1, 2, 3, 4)
+
+    # A deque can be used as a stack
+    # https://en.wikipedia.org/wiki/Stack_(abstract_data_type)
+    assert dq.pop() == 4
+    assert dq.pop() == 3
+
+    # A deque can be used as a queue
+    # https://en.wikipedia.org/wiki/Queue_(abstract_data_type)
+    assert dq.popleft() == 8
+    assert dq.popleft() == 6
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
*Please read the [contributing guidelines](https://github.com/huangsam/ultimate-python/blob/master/CONTRIBUTING.md) before submitting a pull request.*

---

**Describe the change**
Implement deque lesson.

**Additional context**
The general premise behind #25 was sound but it seemed better to leverage a builtin `deque` instead of a hand-rolled doubly-linked list. Added a `deque` lesson and add links to it in both `README` files.