### PR TITLE
Implement datetime lesson

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -107,6 +107,7 @@ Hay dos maneras de ejecutar los módulos:
     - Mocking: [MagicMock | PropertyMock | patch](ultimatepython/advanced/mocking.py) (:exploding_head:)
     - Expresiones regulares: [search | findall | match | fullmatch](ultimatepython/advanced/regex.py) (:exploding_head:)
     - Formatos de datos: [json | xml | csv](ultimatepython/advanced/data_format.py) (:exploding_head:)
+    - Fecha y hora: [datetime | timezone](ultimatepython/advanced/datetime.py) (:exploding_head:)
 
 ## Recursos adicionales
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -96,6 +96,7 @@ Repl.it와 같은 브라우저에서 실행할 수있는 독립형 모듈 모음
     - 조롱 : [MagicMock | PropertyMock | 패치](ultimatepython/advanced/mocking.py) (:exploding_head:)
     - 정규식 : [검색 | findall | 일치 | fullmatch](ultimatepython/advanced/regex.py) (:exploding_head:)
     - 데이터 형식 : [json | xml | csv](ultimatepython/advanced/data_format.py) (:exploding_head:)
+    - 날짜 시간 : [datetime | timezone](ultimatepython/advanced/datetime.py) (:exploding_head:)
 
 ## 추가 자료
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ There are two ways of running the modules:
     - Mocking: [MagicMock | PropertyMock | patch](ultimatepython/advanced/mocking.py) (:exploding_head:)
     - Regular expression: [search | findall | match | fullmatch](ultimatepython/advanced/regex.py) (:exploding_head:)
     - Data format: [json | xml | csv](ultimatepython/advanced/data_format.py) (:exploding_head:)
+    - Datetime: [datetime | timezone](ultimatepython/advanced/datetime.py) (:exploding_head:)
 
 ## Additional resources
 

--- a/README.zh_tw.md
+++ b/README.zh_tw.md
@@ -92,7 +92,7 @@ print("Ultimate Python 學習大綱")
     - 模擬：[MagicMock | PropertyMock | patch](ultimatepython/advanced/mocking.py) (:exploding_head:)
     - 正規表示式：[search | findall | match | fullmatch](ultimatepython/advanced/regex.py) (:exploding_head:)
     - 數據格式：[json | xml | csv](ultimatepython/advanced/data_format.py) (:exploding_head:)
-    - 約會時間: [datetime | timezone](ultimatepython/advanced/datetime.py) (:exploding_head:)
+    - 日期時間: [datetime | timezone](ultimatepython/advanced/datetime.py) (:exploding_head:)
 
 ## 額外資源
 

--- a/README.zh_tw.md
+++ b/README.zh_tw.md
@@ -92,6 +92,7 @@ print("Ultimate Python 學習大綱")
     - 模擬：[MagicMock | PropertyMock | patch](ultimatepython/advanced/mocking.py) (:exploding_head:)
     - 正規表示式：[search | findall | match | fullmatch](ultimatepython/advanced/regex.py) (:exploding_head:)
     - 數據格式：[json | xml | csv](ultimatepython/advanced/data_format.py) (:exploding_head:)
+    - 約會時間: [datetime | timezone](ultimatepython/advanced/datetime.py) (:exploding_head:)
 
 ## 額外資源
 

--- a/ultimatepython/advanced/datetime.py
+++ b/ultimatepython/advanced/datetime.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timezone
+
+
+def convert_dt_to_utc_epoch(dt):
+    """Convert datetime to UTC time in epoch seconds."""
+    return dt.timestamp()
+
+
+def convert_utc_epoch_to_dt(epoch):
+    """Convert epoch seconds to datetime."""
+    return datetime.fromtimestamp(epoch, tz=timezone.utc)
+
+
+def get_utc_now_as_dt():
+    """Get current UTC time as datetime."""
+    return datetime.now(tz=timezone.utc)
+
+
+def get_utc_now_as_epoch():
+    """Get current UTC time as epoch seconds."""
+    return convert_dt_to_utc_epoch(get_utc_now_as_dt())
+
+
+def main():
+    # Create timezone-naive datetime
+    naive_dt = datetime.now()
+    assert naive_dt.tzinfo is None
+
+    # Change timezone-naive datetime to epoch seconds
+    naive_dt_epoch = convert_dt_to_utc_epoch(naive_dt)
+    assert naive_dt_epoch > 0
+
+    # Change epoch seconds to UTC datetime
+    utc_dt = convert_utc_epoch_to_dt(naive_dt_epoch)
+    assert utc_dt.tzinfo is timezone.utc
+    assert convert_dt_to_utc_epoch(utc_dt) == naive_dt_epoch
+
+    # Create new UTC time as datetime
+    utc_dt_new_one = get_utc_now_as_dt()
+    assert utc_dt_new_one > utc_dt
+
+    # Create another new UTC time as epoch seconds
+    utc_epoch_new_two = get_utc_now_as_epoch()
+    utc_epoch_new_one = convert_dt_to_utc_epoch(utc_dt_new_one)
+
+    # Epoch seconds line up as expected
+    assert utc_epoch_new_two > utc_epoch_new_one > naive_dt_epoch
+
+
+if __name__ == "__main__":
+    main()

--- a/ultimatepython/advanced/datetime.py
+++ b/ultimatepython/advanced/datetime.py
@@ -40,7 +40,7 @@ def main():
     assert utc_dt.tzinfo is timezone.utc
     assert convert_dt_to_utc_epoch(utc_dt) == naive_dt_epoch
 
-    # Cannot compute difference between offset-naive and offset-aware
+    # We cannot compute difference between offset-naive and offset-aware
     # datetime objects
     calc_failed = False
     try:
@@ -49,8 +49,8 @@ def main():
         calc_failed = True
     assert calc_failed is True
 
-    # But it is possible to convert the timezone of an offset-naive first
-    # before running operations on them
+    # But we can convert the timezone of an offset-naive first before
+    # running operations on them
     assert convert_dt_timezone(naive_dt, timezone.utc) == utc_dt
 
     # Create new UTC time as datetime

--- a/ultimatepython/advanced/datetime.py
+++ b/ultimatepython/advanced/datetime.py
@@ -49,7 +49,7 @@ def main():
         calc_failed = True
     assert calc_failed is True
 
-    # But we can convert the timezone of an offset-naive first before
+    # But we can change the timezone of an offset-naive first before
     # running operations on them
     assert convert_dt_timezone(naive_dt, timezone.utc) == utc_dt
 

--- a/ultimatepython/advanced/datetime.py
+++ b/ultimatepython/advanced/datetime.py
@@ -2,12 +2,12 @@ from datetime import datetime, timezone
 
 
 def convert_dt_to_utc_epoch(dt):
-    """Convert datetime to UTC time in epoch seconds."""
+    """Convert datetime to UTC epoch seconds."""
     return dt.timestamp()
 
 
 def convert_utc_epoch_to_dt(epoch):
-    """Convert epoch seconds to datetime."""
+    """Convert UTC epoch seconds to datetime."""
     return datetime.fromtimestamp(epoch, tz=timezone.utc)
 
 

--- a/ultimatepython/advanced/datetime.py
+++ b/ultimatepython/advanced/datetime.py
@@ -12,7 +12,7 @@ def convert_utc_epoch_to_dt(epoch):
 
 
 def convert_dt_timezone(dt, tzinfo):
-    """Convert datetime to the given timezone."""
+    """Convert datetime timezone."""
     return dt.astimezone(tz=tzinfo)
 
 

--- a/ultimatepython/advanced/datetime.py
+++ b/ultimatepython/advanced/datetime.py
@@ -22,11 +22,11 @@ def get_utc_now_as_epoch():
 
 
 def main():
-    # Create timezone-naive datetime
+    # Create offset-naive datetime
     naive_dt = datetime.now()
     assert naive_dt.tzinfo is None
 
-    # Change timezone-naive datetime to epoch seconds
+    # Change offset-naive datetime to epoch seconds
     naive_dt_epoch = convert_dt_to_utc_epoch(naive_dt)
     assert naive_dt_epoch > 0
 

--- a/ultimatepython/advanced/datetime.py
+++ b/ultimatepython/advanced/datetime.py
@@ -60,8 +60,6 @@ def main():
     # Create another new UTC time as epoch seconds
     utc_epoch_new_two = get_utc_now_as_epoch()
     utc_epoch_new_one = convert_dt_to_utc_epoch(utc_dt_new_one)
-
-    # Epoch seconds line up as expected
     assert utc_epoch_new_two > utc_epoch_new_one > naive_dt_epoch
 
 

--- a/ultimatepython/advanced/datetime.py
+++ b/ultimatepython/advanced/datetime.py
@@ -40,7 +40,7 @@ def main():
     assert utc_dt.tzinfo is timezone.utc
     assert convert_dt_to_utc_epoch(utc_dt) == naive_dt_epoch
 
-    # We cannot compute difference between offset-naive and offset-aware
+    # We cannot compute differences between offset-naive and offset-aware
     # datetime objects
     calc_failed = False
     try:

--- a/ultimatepython/advanced/datetime.py
+++ b/ultimatepython/advanced/datetime.py
@@ -35,6 +35,15 @@ def main():
     assert utc_dt.tzinfo is timezone.utc
     assert convert_dt_to_utc_epoch(utc_dt) == naive_dt_epoch
 
+    # Cannot compute difference between offset-naive and offset-aware
+    # datetime objects
+    calc_failed = False
+    try:
+        _ = utc_dt - naive_dt
+    except TypeError:
+        calc_failed = True
+    assert calc_failed is True
+
     # Create new UTC time as datetime
     utc_dt_new_one = get_utc_now_as_dt()
     assert utc_dt_new_one > utc_dt

--- a/ultimatepython/advanced/datetime.py
+++ b/ultimatepython/advanced/datetime.py
@@ -11,6 +11,11 @@ def convert_utc_epoch_to_dt(epoch):
     return datetime.fromtimestamp(epoch, tz=timezone.utc)
 
 
+def convert_dt_timezone(dt, tzinfo):
+    """Convert datetime to the given timezone."""
+    return dt.astimezone(tz=tzinfo)
+
+
 def get_utc_now_as_dt():
     """Get current UTC time as datetime."""
     return datetime.now(tz=timezone.utc)
@@ -43,6 +48,10 @@ def main():
     except TypeError:
         calc_failed = True
     assert calc_failed is True
+
+    # But it is possible to convert the timezone of an offset-naive first
+    # before running operations on them
+    assert convert_dt_timezone(naive_dt, timezone.utc) == utc_dt
 
     # Create new UTC time as datetime
     utc_dt_new_one = get_utc_now_as_dt()


### PR DESCRIPTION
*Please read the [contributing guidelines](https://github.com/huangsam/ultimate-python/blob/master/CONTRIBUTING.md) before submitting a pull request.*

---

**Describe the change**
Implement datetime lesson. Add lesson to all `README` variants.

**Additional context**
While doing work on a recent project, I noticed that working with offset-naive vs. offset-aware datetime objects can be a confusing / tricky subject. So I'm creating this module to illustrate the difference between the two types of objects. Furthermore, the functions I created here in this repository should help people become more familiar with the UTC timezone.