### PR TITLE
Revisit the usage of requirements.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,15 +10,15 @@ jobs:
     steps:
       - checkout
       - python/install-packages:
-          pkg-manager: poetry
+          pkg-manager: pip
       - run:
-          command: poetry run flake8
+          command: flake8
           name: Lint
       - run:
-          command: poetry run coverage run -m runner
+          command: coverage run -m runner
           name: Test
       - run:
-          command: poetry run coverage xml -o /tmp/coverage.xml
+          command: coverage xml -o /tmp/coverage.xml
           name: Prepare coverage results
       - store_artifacts:
           path: /tmp/coverage.xml

--- a/poetry.lock
+++ b/poetry.lock
@@ -136,6 +136,6 @@ files = [
 ]
 
 [metadata]
-lock-version = "2.0"
+lock-version = "1.1"
 python-versions = ">=3.10.0"
 content-hash = "9901dd03a313d274e31212993e5dea80a62b45de7531a02098fbb4dd57fc5c90"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+coverage==7.2.1
+flake8==6.0.0
+isort==5.12.0


### PR DESCRIPTION
*Please read the [contributing guidelines](https://github.com/huangsam/ultimate-python/blob/master/CONTRIBUTING.md) before submitting a pull request.*

---

**Describe the change**
Revisit the usage of requirements.txt

**Additional context**
We want to use the latest Python available in repl.it but it seems like Poetry isn't up-to-date on that environment. This means that the repl.it there cannot read the `poetry.lock` from the official repo.
