### PR TITLE
Adding a tutorial for inheritance to the classes part.

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -96,6 +96,7 @@ Es gibt zwei Möglichkeiten, die Module auszuführen:
     - Time complexity: [cPython operations](https://wiki.python.org/moin/TimeComplexity) (:books:, :exploding_head:)
 4. **Klassen**
     - Basic class: [Basic definition](ultimatepython/classes/basic_class.py) (:cake:)
+    - Inheritance: [Inheritance](ultimatepython/classes/inheritance.py) (:cake:)
     - Abstract class: [Abstract definition](ultimatepython/classes/abstract_class.py)
     - Exception class: [Exception definition](ultimatepython/classes/exception_class.py)
     - Iterator class: [Iterator definition | yield](ultimatepython/classes/iterator_class.py) (:exploding_head:)

--- a/README.es.md
+++ b/README.es.md
@@ -95,6 +95,7 @@ Hay dos maneras de ejecutar los módulos:
     - Complejidad de tiempo: [Operaciones de cPython](https://wiki.python.org/moin/TimeComplexity) (:books:, :exploding_head:)
 4. **Clases**
     - Clase básica: [Definición de básica](ultimatepython/classes/basic_class.py) (:cake:)
+    - Herencia: [Herencia](ultimatepython/classes/inheritance.py) (:cake:)
     - Clase abstracta: [Definición de abstracta](ultimatepython/classes/abstract_class.py)
     - Clase de excepción: [Definición de excepción](ultimatepython/classes/exception_class.py)
     - Clase iteradora: [Definición de iteradora | yield](ultimatepython/classes/iterator_class.py) (:exploding_head:)

--- a/README.ko.md
+++ b/README.ko.md
@@ -85,6 +85,7 @@ print("Ultimate Python 학습 가이드")
     - 시간 복잡도 : [cPython 연산](https://wiki.python.org/moin/TimeComplexity) (:books:, :exploding_head:)
 4. **클래스**
     - 기본 클래스 : [기본 정의](ultimatepython/classes/basic_class.py) (:cake:)
+    - 계승: [계승](ultimatepython/classes/inheritance.py) (:cake:)
     - 추상 클래스 : [추상 정의](ultimatepython/classes/abstract_class.py)
     - 예외 클래스 : [예외 정의](ultimatepython/classes/exception_class.py)
     - 이터레이터 클래스 : [이터레이터 정의 | yield](ultimatepython/classes/iterator_class.py) (:exploding_head:)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ There are two ways of running the modules:
     - Time complexity: [cPython operations](https://wiki.python.org/moin/TimeComplexity) (:books:, :exploding_head:)
 4. **Classes**
     - Basic class: [Basic definition](ultimatepython/classes/basic_class.py) (:cake:)
+    - Inheritance: [Inheritance](ultimatepython/classes/inheritance.py) (:cake:)
     - Abstract class: [Abstract definition](ultimatepython/classes/abstract_class.py)
     - Exception class: [Exception definition](ultimatepython/classes/exception_class.py)
     - Iterator class: [Iterator definition | yield](ultimatepython/classes/iterator_class.py) (:exploding_head:)

--- a/ultimatepython/classes/inheritance.py
+++ b/ultimatepython/classes/inheritance.py
@@ -112,7 +112,7 @@ def main():
     assert ismethod(car.drive) and not isfunction(car.drive)
 
     # If we call the method drive, we can see that we did not
-    # wrote any code for the car class, but we can still use it
+    # write any code for the car class, but we can still use it
     # because it is inherited from the vehicle class and the
     # behavior is the same as the vehicle
     assert car.drive(50) == "DeLorean DMC-12 (1982) is driving at 50 MPH"

--- a/ultimatepython/classes/inheritance.py
+++ b/ultimatepython/classes/inheritance.py
@@ -1,0 +1,133 @@
+"""
+Inheritance is a way to reuse code and data from a parent class. This
+allow us to avoid repeating ourselves and to build upon existing
+functionality. This module defines a basic vehicle class, creates a car
+class that inherits from vehicle, then creates a truck class that
+inherits from car and use it for demonstration purposes.
+"""
+from inspect import isfunction, ismethod, signature
+
+class Vehicle:
+    """Basic definition of a vehicle.
+
+    We begin with a simple mental model of what a vehicle is. It has 
+    a make, model, year, and miles. That way, we can start exploring
+    the core concepts that are associated with a class definition.
+    """
+
+    def __init__(self, make, model, year, miles):
+        """Construct a vehicle with make, model, year, and miles."""
+        self.make = make
+        self.model = model
+        self.year = year
+        self.miles = miles
+
+    def __repr__(self):
+        """Return the formal representation of a vehicle."""
+        return f"<Vehicle make={self.make} model={self.model} year={self.year}>"
+
+    def __str__(self):
+        """Return the informal representation of a vehicle."""
+        return f"{self.make} {self.model} ({self.year})"
+
+    def drive(self, rate_in_mph):
+        """Drive a vehicle at a certain rate in MPH."""
+        return f"{self} is driving at {rate_in_mph} MPH"
+
+
+class Car(Vehicle):
+    """Definition of a car.
+
+    We inherit from the vehicle class to reuse the code and data that
+    we have already defined. In addition, we add a new attribute called
+    `wheels` to the car class. This is an example of extending the
+    functionality of a parent class. In __init__, we call the parent
+    constructor with the `super` function. This is a way to invoke the
+    parent constructor without having to explicitly name the parent
+    class. We also override the method `__repr__` to have a different
+    output than the vehicle.
+    """
+
+    def __init__(self, make, model, year, miles):
+        """Construct a car with make, model, year, miles, and wheels."""
+        super().__init__(make, model, year, miles)
+        self.wheels = 4
+    
+    def __repr__(self):
+        """Return the formal representation of a car."""
+        return f"<Car make={self.make} model={self.model} year={self.year} wheels={self.wheels}>"
+    
+
+class Truck(Vehicle):
+    """Definition of a truck.
+
+    We inherit from vehicle just like we did with the car class. In this case we
+    will also override the method `drive` to have a different output than the
+    car and the vehicle.
+    """
+
+    def __init__(self, make, model, year, miles):
+        """Construct a truck with make, model, year, miles, and wheels."""
+        super().__init__(make, model, year, miles)
+        self.wheels = 6
+    
+    def __repr__(self):
+        """Return the formal representation of a truck."""
+        return f"<Truck make={self.make} model={self.model} year={self.year} wheels={self.wheels}>"
+    
+    def drive(self, rate_in_mph):
+        """Drive a truck at a certain rate in MPH."""
+        return f"{self} is driving a truck at {rate_in_mph} MPH"
+
+
+def main():
+    # Create a vehicle with the provided class constructor
+    vehicle = Vehicle("Mistery Machine", "Van", 1969, 100000.0)
+    
+    # Formal representation
+    assert repr(vehicle) == "<Vehicle make=Mistery Machine model=Van year=1969>"
+
+    # Informal representation
+    assert str(vehicle) == "Mistery Machine Van (1969)"
+
+    # Call a method on the class constructor
+    assert vehicle.drive(50) == "Mistery Machine Van (1969) is driving at 50 MPH"
+
+    # Check the type of the method drive
+    assert ismethod(vehicle.drive) and not isfunction(vehicle.drive)
+
+    # Now we create a car with the provided class constructor
+    car = Car("DeLorean", "DMC-12", 1982, 220000.0)
+
+    # The informal representation is similar to the vehicle
+    assert str(car) == "DeLorean DMC-12 (1982)"
+
+    # But the formal representation is different because we included
+    # the wheels attribute
+    assert repr(car) == "<Car make=DeLorean model=DMC-12 year=1982 wheels=4>"
+
+    # And we can check the type of the method drive like we did with
+    # the vehicle
+    assert ismethod(car.drive) and not isfunction(car.drive)
+
+    # Now we create a truck with the provided class constructor
+    truck = Truck("Optimus Prime", "Truck", 1984, 1000000.0)
+
+    # Like car and vehicle, the informal representation is similar
+    assert str(truck) == "Optimus Prime Truck (1984)"
+
+    # And the formal representation is different from the vehicle 
+    # because we included the wheels attribute
+    assert repr(truck) == "<Truck make=Optimus Prime model=Truck year=1984 wheels=6>"
+
+    # And we can check the type of the method drive like we did with
+    # the vehicle
+    assert ismethod(truck.drive) and not isfunction(truck.drive)
+
+    # For the last part, we can see that the method drive is different
+    # for the truck
+    assert truck.drive(50) == "Optimus Prime Truck (1984) is driving a truck at 50 MPH"
+
+
+if __name__ == "__main__":
+    main()

--- a/ultimatepython/classes/inheritance.py
+++ b/ultimatepython/classes/inheritance.py
@@ -5,12 +5,13 @@ functionality. This module defines a basic vehicle class, creates a car
 class that inherits from vehicle, then creates a truck class that
 inherits from car and use it for demonstration purposes.
 """
-from inspect import isfunction, ismethod, signature
+from inspect import isfunction, ismethod
+
 
 class Vehicle:
     """Basic definition of a vehicle.
 
-    We begin with a simple mental model of what a vehicle is. It has 
+    We begin with a simple mental model of what a vehicle is. It has
     a make, model, year, and miles. That way, we can start exploring
     the core concepts that are associated with a class definition.
     """
@@ -52,11 +53,11 @@ class Car(Vehicle):
         """Construct a car with make, model, year, miles, and wheels."""
         super().__init__(make, model, year, miles)
         self.wheels = 4
-    
+
     def __repr__(self):
         """Return the formal representation of a car."""
         return f"<Car make={self.make} model={self.model} year={self.year} wheels={self.wheels}>"
-    
+
 
 class Truck(Vehicle):
     """Definition of a truck.
@@ -70,11 +71,11 @@ class Truck(Vehicle):
         """Construct a truck with make, model, year, miles, and wheels."""
         super().__init__(make, model, year, miles)
         self.wheels = 6
-    
+
     def __repr__(self):
         """Return the formal representation of a truck."""
         return f"<Truck make={self.make} model={self.model} year={self.year} wheels={self.wheels}>"
-    
+
     def drive(self, rate_in_mph):
         """Drive a truck at a certain rate in MPH."""
         return f"{self} is driving a truck at {rate_in_mph} MPH"
@@ -83,7 +84,7 @@ class Truck(Vehicle):
 def main():
     # Create a vehicle with the provided class constructor
     vehicle = Vehicle("Mistery Machine", "Van", 1969, 100000.0)
-    
+
     # Formal representation
     assert repr(vehicle) == "<Vehicle make=Mistery Machine model=Van year=1969>"
 
@@ -116,7 +117,7 @@ def main():
     # Like car and vehicle, the informal representation is similar
     assert str(truck) == "Optimus Prime Truck (1984)"
 
-    # And the formal representation is different from the vehicle 
+    # And the formal representation is different from the vehicle
     # because we included the wheels attribute
     assert repr(truck) == "<Truck make=Optimus Prime model=Truck year=1984 wheels=6>"
 

--- a/ultimatepython/classes/inheritance.py
+++ b/ultimatepython/classes/inheritance.py
@@ -111,6 +111,12 @@ def main():
     # the vehicle
     assert ismethod(car.drive) and not isfunction(car.drive)
 
+    # If we call the method drive, we can see that we did not
+    # wrote any code for the car class, but we can still use it
+    # because it is inherited from the vehicle class and the
+    # behavior is the same as the vehicle
+    assert car.drive(50) == "DeLorean DMC-12 (1982) is driving at 50 MPH"
+
     # Now we create a truck with the provided class constructor
     truck = Truck("Optimus Prime", "Truck", 1984, 1000000.0)
 


### PR DESCRIPTION
**Describe the change**
I added a module for inheritance in classes. 

**Additional context**
This is because it seems to me that the tutorial has a gap between `basic_class` and `abstract_class`. Also there are some concepts that are intuitively used in the advanced part that could be useful to be introduced earlier (like super).

I added this in a reference from the [python docs](https://docs.python.org/3/tutorial/classes.html#inheritance).